### PR TITLE
Migrate to MCP SDK v2 (mcp[cli]>=1.6.0 currently resolves to 2.0.0 and fails at import)

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from mcp.server.mcpserver import MCPServer
 # Load environment variables from .env file
 load_dotenv()
 
-# Initialize FastMCP server
+# Initialize MCPServer
 mcp = MCPServer("bangumi-tv")
 
 # Import and register all components

--- a/main.py
+++ b/main.py
@@ -4,13 +4,13 @@ import atexit
 import os
 
 from dotenv import load_dotenv
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 # Load environment variables from .env file
 load_dotenv()
 
 # Initialize FastMCP server
-mcp = FastMCP("bangumi-tv")
+mcp = MCPServer("bangumi-tv")
 
 # Import and register all components
 from src.resources import openapi_resource

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "For Bangumi TV API MCP Service"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp[cli]>=1.6.0",
+    "mcp[cli]>=2.0.0,<3",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
 ]


### PR DESCRIPTION
## `mcp[cli]>=1.6.0` currently resolves to 2.0.0

`pyproject.toml` sets no upper bound, so a fresh install pulls MCP Python SDK 2.0.0 and `main.py` fails at import:

    ModuleNotFoundError: No module named 'mcp.server.fastmcp'

`mcp.server.fastmcp` was removed in v2 and `FastMCP` was renamed to `MCPServer`.

## Two ways to fix it

**Pin below 2.** The SDK's migration guide recommends keeping a `<2` upper bound until you've migrated — one line, and entirely reasonable. Close this if that's your preference.

**Or migrate**, which is what this PR does.

## The diff

The two code changes are mechanical renames, generated by a tool I've been building ([api-drift](https://github.com/LucasAbud11/api-drift)) from the SDK's published v1→v2 migration guide. `.tool()`, `.resource()`, `.prompt()` and `.run()` are all unchanged in v2, so the 55 registered tools, the resources and the prompts need no changes.

I also bumped the pin to `mcp[cli]>=2.0.0,<3` — without it the migrated import breaks for anyone with 1.x installed.

## One thing to check on your side

v2 changed the default HTTP bind address. `run_sse_async` and `run_streamable_http_async` now default to `host="127.0.0.1"`, where v1 defaulted to `0.0.0.0`. `main.py` calls `mcp.run(transport=transport)` without a host, so if you run this with `MCP_TRANSPORT=sse` or `streamable-http` inside Docker it would bind to localhost within the container and be unreachable from outside.

Nothing in this PR changes that behaviour, and I didn't want to guess at your deployment — but you may want `mcp.run(transport=transport, host="0.0.0.0", port=...)` for the HTTP transports. Happy to add it if you'd like.

## Verification

Checked against a real `mcp==2.0.0` install: the new import resolves, `MCPServer("bangumi-tv")` constructs, and `.tool()`, `.resource()`, `.prompt()`, `.run()` are all present.